### PR TITLE
Fixed saving of HPIHPB

### DIFF
--- a/archive_hpi_hpb/HPIHPB.cs
+++ b/archive_hpi_hpb/HPIHPB.cs
@@ -108,7 +108,7 @@ namespace archive_hpi_hpb
 
                     if (entry.Entry.State == ArchiveFileState.Added)
                     {
-                        byte[] data = new BinaryReaderX(entry.Entry.FileData).ReadBytes((int)entry.Entry.FileData.Length);
+                        byte[] data = new BinaryReaderX(entry.Entry.fileDataOrig).ReadBytes((int)entry.Entry.fileDataOrig.Length);
                         hpbBw.Write(data, 0, data.Count());
 
                         // File Length
@@ -119,23 +119,19 @@ namespace archive_hpi_hpb
                     }
                     else
                     {
-                        Stream compData = entry.Entry.FileData;
+                        Stream compData = entry.Entry.fileDataOrig;
 
                         if (entry.Entry.State == ArchiveFileState.Replaced && entry.Entry.Entry.uncompressedSize != 0)
                         {
-                            compData = entry.Entry.GetCompressedStream(entry.Entry.FileData);
+                            compData = entry.Entry.GetCompressedStream(entry.Entry.fileDataOrig);
 
                             // ACMP Header
                             hpbBw.WriteASCII("ACMP");
                             hpbBw.Write((int)compData.Length + 0x20);
                             hpbBw.Write(0x20);
                             hpbBw.Write(0);
-                            hpbBw.Write((int)entry.Entry.FileData.Length);
+                            hpbBw.Write((int)entry.Entry.fileDataOrig.Length);
                             for (int j = 0; j < 3; j++) hpbBw.Write(0x01234567);
-                        }
-                        else
-                        {
-                            compData = entry.Entry.FileData;
                         }
 
                         byte[] data = new BinaryReaderX(compData).ReadBytes((int)compData.Length);
@@ -148,14 +144,14 @@ namespace archive_hpi_hpb
 
                         // Uncompressed Size
                         if (entry.Entry.State == ArchiveFileState.Replaced && entry.Entry.Entry.uncompressedSize != 0)
-                            hpiBw.Write((int)entry.Entry.FileData.Length);
+                            hpiBw.Write((int)entry.Entry.fileDataOrig.Length);
                         else hpiBw.Write((int)entry.Entry.Entry.uncompressedSize);
                     }
                     count++;
                 }
             }
 
-            hpbBw.Close();
+            hpbBw.Dispose();
         }
 
         public void Dispose()

--- a/archive_hpi_hpb/HpiHbpSupport.cs
+++ b/archive_hpi_hpb/HpiHbpSupport.cs
@@ -58,13 +58,15 @@ namespace archive_hpi_hpb
     {
         public Entry Entry;
 
-        public override Stream FileData => base.FileData ?? GetUncompressedStream();
+        public override Stream FileData => GetUncompressedStream(base.FileData);
 
-        public Stream GetUncompressedStream()
+        public Stream fileDataOrig => base.FileData;
+
+        public Stream GetUncompressedStream(Stream fileData)
         {
-            FileData.Position = 0;
-            if (Entry.uncompressedSize == 0) return FileData;
-            using (var br = new BinaryReaderX(FileData, true))
+            fileData.Position = 0;
+            if (Entry.uncompressedSize == 0) return fileData;
+            using (var br = new BinaryReaderX(fileData, true))
             {
                 var header = br.ReadStruct<AcmpHeader>();
                 return new MemoryStream(RevLZ77.Decompress(br.ReadBytes(header.compressedSize), header.uncompressedSize));

--- a/archive_hpi_hpb/HpiHpbManager.cs
+++ b/archive_hpi_hpb/HpiHpbManager.cs
@@ -93,7 +93,7 @@ namespace archive_hpi_hpb
                 _fileInfo = new FileInfo(filename);
 
             var hpiFilename = _fileInfo.FullName;
-            var hpbFilename = _fileInfo.FullName.Remove(filename.Length - 1) + "B";
+            var hpbFilename = _fileInfo.FullName.Remove(_fileInfo.FullName.Length - 1) + "B";
 
             try
             {


### PR DESCRIPTION
Had to introduce another stream variable beside the normal FileData.
Because of the modified getter both uncompressed and compressed streams were tried to uncompress which leads to an overflow at worst. So having a FileData with modified getter for the UI to grasp the uncompressed stream and a "normal" fileDataOrig which grasps the unedited (added or replaced) filestream resolved the problem.