### PR TITLE
HuneX Filename Fixes

### DIFF
--- a/src/archive/archive_hunex/HED.cs
+++ b/src/archive/archive_hunex/HED.cs
@@ -86,7 +86,7 @@ namespace archive_hunex
                 Files = Entries.Select(o => new HEDFileInfo
                 {
                     Entry = o,
-                    FileName = String.Format("{0}-{1}.mzx", o.Name, o.Suffix),
+                    FileName = String.Format("{0}-{1}{2}", o.Name, o.Suffix, o.Extension),
                     FileData = new SubStream(mrgStream, o.Offset, o.Size),
                     State = ArchiveFileState.Archived
                 }).ToList();


### PR DESCRIPTION
Fixes a few errors that may occur with filenames from the .nam files.

Also now respects the extension given to files by the .nam file, if no extension is found it will simply use .mxz