### PR TITLE
Improve BMG Compatibility

### DIFF
--- a/src/text/text_bmg/BMG.cs
+++ b/src/text/text_bmg/BMG.cs
@@ -89,6 +89,8 @@ namespace text_bmg
                     items.Add(new Item { strOffset = br.ReadInt32(), attr = br.ReadBytes(itemSize - 4) });
                 }
 
+                // Reset the stream position to immediately after the header.
+                br.BaseStream.Position = headerSize;
 
                 var strs = new List<string>();
                 for (var i = 0; i < header.sectionCount - 1; i++)

--- a/src/text/text_bmg/BmgAdapter.cs
+++ b/src/text/text_bmg/BmgAdapter.cs
@@ -22,7 +22,7 @@ namespace text_bmg
 
         // Information
         public string Name => "BMG";
-        public string Description => "Mario Kart Script";
+        public string Description => "Binary Message Group";
         public string Extension => "*.bmg";
         public string About => "This is the BMG text adapter for Kuriimu.";
 

--- a/src/text/text_bmg/BmgSupport.cs
+++ b/src/text/text_bmg/BmgSupport.cs
@@ -87,20 +87,27 @@ namespace text_bmg
     }
     #endregion
 
+    public enum BmgEncoding : byte
+    {
+        Unknown = 0,
+        ASCII = 1,
+        UTF16 = 2,
+        ShiftJIS = 3
+    }
 
-    [StructLayout(LayoutKind.Sequential, Pack = 1)]
-    public class MESGHeader
+    [StructLayout(LayoutKind.Sequential, Pack = 1, Size = 32)]
+    public struct MESGHeader
     {
         public Magic8 magic;
         public int fileSize;
         public int sectionCount;
-        public int unk1;
-
+        public BmgEncoding encoding;
     }
 
     public class Item
     {
         public int strOffset;
+        public int size;
         public byte[] attr;
     }
 }


### PR DESCRIPTION
This PR aims to improve the compatibility of BMG files. The old handling of BMG files had a few issues that are now resolved (mainly some files weren't read properly & others didn't support the encoding scheme or binary command scheme.) Closes #469.

Command parsing was disabled to improve compatibility.

More improvements should be made to handle custom encodings & command schemes. See source file comments for more info.